### PR TITLE
Add use with python3 in the classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
     ],
     keywords='image resize resizing python',
     packages=find_packages(),


### PR DESCRIPTION
According to the README.\* file, the library works with python 3.4. This patch add it to the classifiers to help users to find it.
