### PR TITLE
adds background color to resize_contain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ venv
 dist
 build
 .coverage
+
+#Banish OSX filesystem trash
+.DS_Store
+
+# test images
+tests/tmp-images

--- a/resizeimage/resizeimage.py
+++ b/resizeimage/resizeimage.py
@@ -95,16 +95,18 @@ def resize_cover(image, size):
     return img
 
 
-def resize_contain(image, size):
+def resize_contain(image, size, bgcolor=(255,255,255,0)):
     """
     Resize image according to size.
     image:      a Pillow image instance
     size:       a list of two integers [width, height]
+    bgcolor:    a Pillow ImageColor (e.g. hex-strings "#FFFFFF"
+                    or RGB function values [255,255,255])
     """
     img_format = image.format
     img = image.copy()
     img.thumbnail((size[0], size[1]), Image.LANCZOS)
-    background = Image.new('RGBA', (size[0], size[1]), (255, 255, 255, 0))
+    background = Image.new('RGBA', (size[0], size[1]), bgcolor)
     img_position = (
         int(math.ceil((size[0] - img.size[0]) / 2)),
         int(math.ceil((size[1] - img.size[1]) / 2))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -153,6 +153,24 @@ class TestResizeimage(unittest.TestCase):
             with Image.open(filename) as image:
                 self.assertEqual(image.size, (801, 534))
 
+    def test_resize_contain_bgcolor(self):
+        """
+        Test that the image resized with resize_contain
+        and a bgcolor has the correct background color
+        in the background
+        """
+        with self._open_test_image() as img:
+            # testcolor evaluation only works when doing a (R,G,B)-type
+            # color, not a hexstring, though its totally valid to send
+            # a hexstring
+            testcolor = (127, 128, 0)
+            img = resizeimage.resize_contain(img, [200, 100], testcolor)
+            filename = self._tmp_filename('resize-contain-bgcolor.jpeg')
+            img.save(filename, img.format)
+            with Image.open(filename) as image:
+                image_rgb = image.convert('RGB')
+                self.assertEqual(image_rgb.getpixel((1, 1)), testcolor)
+
     def test_resize_width(self):
         """
         Test that the image resized with resize_width


### PR DESCRIPTION
I was looking to specify a background color on the `resize_contain` method.
- Adds an additional parameter (`bgcolor`) to the method `resize_contain`, allowing any [Pillow ImageColor](http://pillow.readthedocs.io/en/3.3.x/reference/ImageColor.html) as an acceptable value.
- ignores test image in .gitignore

Worth noting: this was committed without the pre-commit hooks. While my tests passed, some of the other code in the tests wasn't passing to the standards.
