### PR TITLE
Support Python 3.5 & 3.6 and pin dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
 
 install:
   - pip install -q tox

--- a/resizeimage/resizeimage.py
+++ b/resizeimage/resizeimage.py
@@ -111,7 +111,7 @@ def resize_contain(image, size):
     )
     background.paste(img, img_position)
     background.format = img_format
-    return background
+    return background.convert('RGB')
 
 
 @validate(_width_is_big_enough)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
     ],
     keywords='image resize resizing python',
     packages=find_packages(),
-    install_requires=['pillow', 'requests'],
+    install_requires=['Pillow>=5.1.0', 'requests>=2.19.1'],
     test_suite='tests',
 )

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords='image resize resizing python',
     packages=find_packages(),


### PR DESCRIPTION
This PR enables support for Python 3.5 & 3.6, and pins the `Pillow` and `requests` dependencies to their latest versions. Since the last release was in Jan 2017, the tests broke after pinning `Pillow` to `5.1.0`, but adding a `convert('RGB')` in `resize_contains` fixed the broken tests.