### PR TITLE
fix - convert to RGBA, not only RGB

### DIFF
--- a/resizeimage/resizeimage.py
+++ b/resizeimage/resizeimage.py
@@ -111,7 +111,8 @@ def resize_contain(image, size, resample=Image.LANCZOS, bg_color=(255, 255, 255,
     )
     background.paste(img, img_position)
     background.format = img_format
-    return background.convert('RGB')
+    resized_img = background.convert('RGBA') 
+    return resized_img
 
 
 @validate(_width_is_big_enough)


### PR DESCRIPTION
As pointed out by @bugsel in the issues (#26), the alpha channel information was lost in the last line of the `resize_contain` function because the conversion was done to RGB.