### PR TITLE
Fix crash when trying to specify resample argument

### DIFF
--- a/resizeimage/resizeimage.py
+++ b/resizeimage/resizeimage.py
@@ -26,10 +26,10 @@ def validate(validator):
         """Bound decorator to a particular validator function"""
 
         @wraps(func)
-        def wrapper(image, size, validate=True):
+        def wrapper(image, size, validate=True, *args, **kwargs):
             if validate:
                 validator(image, size)
-            return func(image, size)
+            return func(image, size, *args, **kwargs)
         return wrapper
 
     return decorator


### PR DESCRIPTION
Wrapper didn't correctly forward `resample` argument to wrapped functions disallowing calls to functions like `resize_cover`, `resize_width`, `resize_height` to specify `resample` argument.

Fixed by forwading all positional and named arguments to wrapped function.