### PR TITLE
Mitigate CWE-400, add a timeout

### DIFF
--- a/resizeimage/helpers.py
+++ b/resizeimage/helpers.py
@@ -15,7 +15,7 @@ def url_to_image(url):
     """
     Fetch an image from url and convert it into a Pillow Image object
     """
-    r = requests.get(url)
+    r = requests.get(url, timeout=(3.05, 10))
     image = StringIO(r.content)
     return image
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,6 +7,27 @@ from PIL import Image
 
 from resizeimage import resizeimage
 from resizeimage.imageexceptions import ImageSizeError
+from resizeimage.helpers import url_to_image
+
+try:
+    from mock import patch, Mock
+except ImportError:
+    from unittest.mock import patch, Mock
+
+
+class TestHelpers(unittest.TestCase):
+
+    @patch('resizeimage.helpers.requests.get')
+    def test_url_to_image_uses_timeout(self, mock_get):
+        mock_get.return_value = Mock(content=b'fake-image-bytes')
+
+        image = url_to_image('http://example.com/test.jpg')
+
+        mock_get.assert_called_once_with(
+            'http://example.com/test.jpg',
+            timeout=(3.05, 10)
+        )
+        self.assertEqual(image.getvalue(), b'fake-image-bytes')
 
 
 class TestValidateDecorator(unittest.TestCase):


### PR DESCRIPTION
Without a timeout set, the call to an external URL could lead to resource exhaustion or denial of service.